### PR TITLE
Flip default sandbox images to ghcr.io/nightona-co

### DIFF
--- a/.github/workflows/e2e_pr_tests.yaml
+++ b/.github/workflows/e2e_pr_tests.yaml
@@ -14,6 +14,7 @@ on:
 
 permissions:
   contents: read
+  packages: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -88,6 +89,18 @@ jobs:
           sudo systemctl restart docker
           sudo systemctl is-active docker
 
+      - name: Log in to GHCR and pre-pull default sandbox image
+        if: steps.affected.outputs.affected == 'true'
+        env:
+          GHCR_USER: ${{ github.actor }}
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # The ghcr.io/nightona-co sandbox packages may still be private;
+          # authenticate with the workflow token (harmless once public) and
+          # pre-seed the image so the runner finds it locally.
+          echo "$GHCR_TOKEN" | docker login ghcr.io -u "$GHCR_USER" --password-stdin
+          docker pull ghcr.io/nightona-co/sandbox:0.6.0-slim
+
       - name: Start infrastructure (postgres, redis, dex, registry)
         if: steps.affected.outputs.affected == 'true'
         run: |
@@ -144,6 +157,22 @@ jobs:
           tail -50 /tmp/runner.log 2>/dev/null || echo "No runner logs found"
           exit 1
 
+      - name: Register GHCR credentials with API
+        if: steps.affected.outputs.affected == 'true'
+        env:
+          GHCR_USER: ${{ github.actor }}
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Register ghcr.io as a source registry so the API/runner can
+          # inspect and pull the (possibly still private) default sandbox
+          # image with authenticated requests. Must happen before a runner
+          # becomes READY, i.e. before the pending default snapshot is
+          # processed — the API is up but the runner is still booting here.
+          curl -sf -X POST http://localhost:3001/api/docker-registry \
+            -H "Authorization: Bearer e2e_admin_api_key" \
+            -H "Content-Type: application/json" \
+            -d "{\"name\":\"GHCR CI\",\"url\":\"ghcr.io\",\"username\":\"${GHCR_USER}\",\"password\":\"${GHCR_TOKEN}\"}"
+
       - name: Start proxy and dashboard
         if: steps.affected.outputs.affected == 'true'
         run: |
@@ -160,12 +189,12 @@ jobs:
       - name: Wait for default snapshot to be available
         if: steps.affected.outputs.affected == 'true'
         run: |
-          echo "Waiting for default snapshot (daytonaio/sandbox:0.6.0-slim) to become active..."
+          echo "Waiting for default snapshot (ghcr.io/nightona-co/sandbox:0.6.0-slim) to become active..."
           echo "Runner must boot, API creates snapshot (pending), cron job transitions it to active"
           for i in $(seq 1 150); do
             BODY=$(curl -s \
               -H "Authorization: Bearer e2e_admin_api_key" \
-              "http://localhost:3001/api/snapshots/daytonaio%2Fsandbox%3A0.6.0-slim" 2>/dev/null || echo "")
+              "http://localhost:3001/api/snapshots/ghcr.io%2Fnightona-co%2Fsandbox%3A0.6.0-slim" 2>/dev/null || echo "")
             STATE=$(echo "$BODY" | jq -r '.state // empty' 2>/dev/null || echo "")
             if [ "$STATE" = "active" ]; then
               echo "Default snapshot is active (attempt $i, elapsed ~$((i*2))s)"

--- a/apps/nightona-e2e/.env.e2e
+++ b/apps/nightona-e2e/.env.e2e
@@ -16,7 +16,7 @@ OIDC_CLIENT_ID=nightona
 OIDC_ISSUER_BASE_URL=http://localhost:5556/dex
 OIDC_AUDIENCE=nightona
 
-DEFAULT_SNAPSHOT=daytonaio/sandbox:0.6.0-slim
+DEFAULT_SNAPSHOT=ghcr.io/nightona-co/sandbox:0.6.0-slim
 DASHBOARD_URL=http://localhost:3000/dashboard
 DASHBOARD_BASE_API_URL=http://localhost:3000
 

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -8,7 +8,7 @@ services:
       - OTEL_ENABLED=true
       - OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4318
       # Default to slim image for faster startup
-      - DEFAULT_SNAPSHOT=daytonaio/sandbox:0.5.0-slim
+      - DEFAULT_SNAPSHOT=ghcr.io/nightona-co/sandbox:0.6.0-slim
       - ENCRYPTION_KEY=supersecretkey
       - ENCRYPTION_SALT=supersecretsalt
       - NODE_ENV=production


### PR DESCRIPTION
Switches the functional default sandbox image references from upstream `daytonaio/sandbox` to our published `ghcr.io/nightona-co/sandbox` images.

## Flipped sites
- `apps/nightona-e2e/.env.e2e` — `DEFAULT_SNAPSHOT` -> `ghcr.io/nightona-co/sandbox:0.6.0-slim`
- `docker/docker-compose.yaml` — API `DEFAULT_SNAPSHOT` -> `ghcr.io/nightona-co/sandbox:0.6.0-slim` (was `daytonaio/sandbox:0.5.0-slim`; we publish 0.6.0)
- `.github/workflows/e2e_pr_tests.yaml` — snapshot wait step now polls `ghcr.io%2Fnightona-co%2Fsandbox%3A0.6.0-slim`

## GHCR auth (packages may still be private)
- Workflow permissions now include `packages: read`
- New step: `docker login ghcr.io` (github.actor + GITHUB_TOKEN) and pre-pull of the sandbox image, so the runner finds it locally
- New step: registers `ghcr.io` as a source registry via the API (admin key) before the runner becomes READY, so the API-side registry digest inspect (`DistributionInspect`) and the runner pull are authenticated. Both steps are harmless once the packages flip to public.

## Deferred (cosmetic/legacy, untouched)
OpenAPI DTO example strings, docs snippets (`apps/docs`), generated openapi specs, `images/*` READMEs, `sandbox-gpu` Dockerfile FROM base, `migration.ts` `LIKE 'daytonaio/%'` legacy matcher, `scripts/setup-domain-oss-deployment.sh` pull (external users lack GHCR auth until packages are public) — ~70 occurrences.